### PR TITLE
Changing the specification method of host file

### DIFF
--- a/1-server_unit/ansible.cfg
+++ b/1-server_unit/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = /root/ansible/static_inventory/
+inventory = /root/ansible/static_inventory/
 host_key_checking = False
 gathering = explicit
 log_path=/root/ansible.log

--- a/3-server_unit/ansible.cfg
+++ b/3-server_unit/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = /root/ansible/static_inventory/
+inventory = /root/ansible/static_inventory/
 host_key_checking = False
 gathering = explicit
 log_path=/root/ansible.log


### PR DESCRIPTION
In the cfg file, we used a variable name that is deprecated as the host placement destination, 
so we can not read the host file.

Change the variable name to the recommended name.