### PR TITLE
Add map and proxy_set_header for websocket

### DIFF
--- a/1-server_unit/resource/web/opt/nginx/conf/nginx.conf
+++ b/1-server_unit/resource/web/opt/nginx/conf/nginx.conf
@@ -44,6 +44,11 @@ http {
                             '"$ssl_cipher" "$ssl_protocol" '
                             '$request_time $upstream_response_time';
 
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      '' close;
+    }
+
     server {
         listen                  443 default_server ssl;
         include                 server_name.conf;
@@ -106,6 +111,8 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Path $request_uri;
             proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_hide_header X-Powered-By;
             proxy_hide_header X-Rack-Cache;
             proxy_hide_header X-Content-Digest;

--- a/3-server_unit/resource/web/opt/nginx/conf/nginx.conf
+++ b/3-server_unit/resource/web/opt/nginx/conf/nginx.conf
@@ -44,6 +44,11 @@ http {
                             '"$ssl_cipher" "$ssl_protocol" '
                             '$request_time $upstream_response_time';
 
+    map $http_upgrade $connection_upgrade {
+      default upgrade;
+      '' close;
+    }
+
     server {
         listen                  443 default_server ssl;
         include                 server_name.conf;
@@ -106,6 +111,8 @@ http {
             proxy_set_header X-Forwarded-Proto https;
             proxy_set_header X-Forwarded-Path $request_uri;
             proxy_set_header Host $http_host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
             proxy_hide_header X-Powered-By;
             proxy_hide_header X-Rack-Cache;
             proxy_hide_header X-Content-Digest;


### PR DESCRIPTION
In order to use WebSocket, it needs to pass the Upgrade and the Connection header to the personium-core servlet from clients.

Reference: http://nginx.org/en/docs/http/websocket.html