### PR TITLE
Correction related to ansible(#21,#22,#23,#26)

### DIFF
--- a/1-server_unit/resource/ap/personium/personium-core/conf/18888/personium-unit-config.properties.j2
+++ b/1-server_unit/resource/ap/personium/personium-core/conf/18888/personium-unit-config.properties.j2
@@ -40,7 +40,7 @@ io.personium.core.plugin.path=/personium/personium-core/plugins
 #
 # If you do not specify anything, the certificate of Personium's offical
 # CA will automatically be trusted.
-io.personium.core.x509.root=/opt/x509/unit-self-sign.crt /opt/x509/cacert.crt
+io.personium.core.x509.root=/opt/x509/unit-self-sign.crt
 
 # File path to the X509 certificate file.
 io.personium.core.x509.crt=/opt/x509/unit-self-sign.crt

--- a/1-server_unit/resource/es/personium/check_cluster_health.sh
+++ b/1-server_unit/resource/es/personium/check_cluster_health.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Shell script for checking Elasticsearch's cluster health
+#
+
+ES_IP=$1
+CLUSTER_HEALTH_STATUS=red
+
+while [ $CLUSTER_HEALTH_STATUS = "red" ]
+do
+    CLUSTER_HEALTH_STATUS=`curl -X GET 'http://${ES_IP}:9200/_cluster/health' | cut -d',' -f2 | cut -d':' -f2 | tr -d '"'`
+    
+    if [ $CLUSTER_HEALTH_STATUS != "green" && $CLUSTER_HEALTH_STATUS != "yellow" ]; then
+        CLUSTER_HEALTH_STATUS=red
+        sleep 30
+    fi
+
+done

--- a/1-server_unit/tasks/bastion/git_clone.yml
+++ b/1-server_unit/tasks/bastion/git_clone.yml
@@ -9,6 +9,7 @@
     dest: /tmp/personium-core
     version: "{{ personium_core_version }}"
     depth: 1
+    force: yes
 
 - name: git clone engine repo
   git:
@@ -16,3 +17,4 @@
     dest: /tmp/personium-engine
     version: "{{ personium_engine_version }}"
     depth: 1
+    force: yes

--- a/1-server_unit/tasks/common/config_firewalld.yml
+++ b/1-server_unit/tasks/common/config_firewalld.yml
@@ -6,10 +6,15 @@
 - name: Deploy /etc/firewalld/zones/personium-zone.xml
   template: src=./resource/{{ tag_ServerType }}/etc/firewalld/zones/personium-zone.xml.j2 dest=/etc/firewalld/zones/personium-zone.xml owner=root group=root mode=0644
 
+- name: restart dbus
+  systemd:
+    name: dbus
+    state: restarted
+
 - name: Start firewalld
   systemd:
     name: firewalld
-    state: started
+    state: restarted
     enabled: yes
 
 - name: Setting default zone

--- a/1-server_unit/tasks/es/init_service_elasticsearch.yml
+++ b/1-server_unit/tasks/es/init_service_elasticsearch.yml
@@ -11,3 +11,9 @@
     name: elasticsearch
     state: started
     enabled: yes
+
+- name: Deploy check_cluster_health.sh
+  copy: src=./resource/es/personium/check_cluster_health.sh dest=/personium/check_cluster_health.sh owner=root group=root mode=0755
+
+- name: exec check_cluster_health.sh
+  command: /bin/bash /personium/check_cluster_health.sh {{base_url}}

--- a/3-server_unit/resource/ap/personium/personium-core/conf/18888/personium-unit-config.properties.j2
+++ b/3-server_unit/resource/ap/personium/personium-core/conf/18888/personium-unit-config.properties.j2
@@ -40,7 +40,7 @@ io.personium.core.plugin.path=/personium/personium-core/plugins
 #
 # If you do not specify anything, the certificate of Personium's offical
 # CA will automatically be trusted.
-io.personium.core.x509.root=/opt/x509/unit-self-sign.crt /opt/x509/cacert.crt
+io.personium.core.x509.root=/opt/x509/unit-self-sign.crt
 
 # File path to the X509 certificate file.
 io.personium.core.x509.crt=/opt/x509/unit-self-sign.crt

--- a/3-server_unit/resource/es/personium/check_cluster_health.sh
+++ b/3-server_unit/resource/es/personium/check_cluster_health.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+#
+# Shell script for checking Elasticsearch's cluster health
+#
+
+ES_IP=$1
+CLUSTER_HEALTH_STATUS=red
+
+while [ $CLUSTER_HEALTH_STATUS = "red" ]
+do
+    CLUSTER_HEALTH_STATUS=`curl -X GET 'http://${ES_IP}:9200/_cluster/health' | cut -d',' -f2 | cut -d':' -f2 | tr -d '"'`
+    
+    if [ $CLUSTER_HEALTH_STATUS != "green" && $CLUSTER_HEALTH_STATUS != "yellow" ]; then
+        CLUSTER_HEALTH_STATUS=red
+        sleep 30
+    fi
+
+done

--- a/3-server_unit/tasks/bastion/git_clone.yml
+++ b/3-server_unit/tasks/bastion/git_clone.yml
@@ -9,6 +9,7 @@
     dest: /tmp/personium-core
     version: "{{ personium_core_version }}"
     depth: 1
+    force: yes
 
 - name: git clone engine repo
   git:
@@ -16,3 +17,4 @@
     dest: /tmp/personium-engine
     version: "{{ personium_engine_version }}"
     depth: 1
+    force: yes

--- a/3-server_unit/tasks/common/config_firewalld.yml
+++ b/3-server_unit/tasks/common/config_firewalld.yml
@@ -6,10 +6,15 @@
 - name: Deploy /etc/firewalld/zones/personium-zone.xml
   template: src=./resource/{{ tag_ServerType }}/etc/firewalld/zones/personium-zone.xml.j2 dest=/etc/firewalld/zones/personium-zone.xml owner=root group=root mode=0644
 
+- name: restart dbus
+  systemd:
+    name: dbus
+    state: restarted
+
 - name: Start firewalld
   systemd:
     name: firewalld
-    state: started
+    state: restarted
     enabled: yes
 
 - name: Setting default zone

--- a/3-server_unit/tasks/es/init_service_elasticsearch.yml
+++ b/3-server_unit/tasks/es/init_service_elasticsearch.yml
@@ -11,3 +11,9 @@
     name: elasticsearch
     state: started
     enabled: yes
+
+- name: Deploy check_cluster_health.sh
+  copy: src=./resource/es/personium/check_cluster_health.sh dest=/personium/check_cluster_health.sh owner=root group=root mode=0755
+
+- name: exec check_cluster_health.sh
+  command: /bin/bash /personium/check_cluster_health.sh {{es_private_ip}}


### PR DESCRIPTION
It corresponds to Issue below.
#21 `git clone core repo` is not idempotent due to LF normalization
#22 `Setting default zone` fails if the firewalld was already started
#23 Missing cacert.crt
#26 An error occurs when Tomcat starts up before Elasticsearch
close #21, close #22, close #23, close #26