### PR TITLE
close #76

### DIFF
--- a/1-server_unit/init_personium.yml
+++ b/1-server_unit/init_personium.yml
@@ -7,6 +7,7 @@
     - ./group_vars/common.yml
     - ./group_vars/bastion.yml
   tasks:
+    - include: ./tasks/common/check_base_url.yml
     - include: ./common.yml
     - include: ./bastion.yml
   handlers:

--- a/1-server_unit/tasks/common/check_base_url.yml
+++ b/1-server_unit/tasks/common/check_base_url.yml
@@ -1,0 +1,6 @@
+# Copyright FUJITSU LIMITED 2018.
+
+- name: Change base_url
+  set_fact:
+    base_url: "{{ base_url[8:] }}"
+  when: base_url is match("^https://")

--- a/3-server_unit/init_personium.yml
+++ b/3-server_unit/init_personium.yml
@@ -7,6 +7,7 @@
     - ./group_vars/common.yml
     - ./group_vars/bastion.yml
   tasks:
+    - include: ./tasks/common/check_base_url.yml
     - include: ./common.yml
     - include: ./bastion.yml
   handlers:

--- a/3-server_unit/tasks/common/check_base_url.yml
+++ b/3-server_unit/tasks/common/check_base_url.yml
@@ -1,0 +1,6 @@
+# Copyright FUJITSU LIMITED 2018.
+
+- name: Change base_url
+  set_fact:
+    base_url: "{{ base_url[8:] }}"
+  when: base_url is match("^https://")


### PR DESCRIPTION
ansible実行時の最初のタスクとして、{base_url}に指定した値をチェックするように修正しました。

チェック内容は、{base_url}に指定した値の先頭が「https://」となっているか。

- 先頭が「https://」の場合

    「https://」を省いた値を変数にもたせ、その後のタスクで使いまわす。

- 先頭が「https://」でない場合

    {base_url}に指定した値をそのまま使い続ける
