### PR TITLE
Add space to error message

### DIFF
--- a/1-server_unit/resource/bastion/tmp/personium-init-svcmgr.sh.j2
+++ b/1-server_unit/resource/bastion/tmp/personium-init-svcmgr.sh.j2
@@ -49,7 +49,7 @@ function check_response() {
   OPERATION=${2}
   RESPONSE_CODE=`echo "${CURL_RESULT}" | /bin/grep 'status:'`
   if [ "${RESPONSE_CODE}" != "status:${STATUS}" ]; then
-    echo "${OPERATION}faild."
+    echo "${OPERATION} faild."
     exit 2
   fi
 }

--- a/3-server_unit/resource/bastion/tmp/personium-init-svcmgr.sh.j2
+++ b/3-server_unit/resource/bastion/tmp/personium-init-svcmgr.sh.j2
@@ -49,7 +49,7 @@ function check_response() {
   OPERATION=${2}
   RESPONSE_CODE=`echo "${CURL_RESULT}" | /bin/grep 'status:'`
   if [ "${RESPONSE_CODE}" != "status:${STATUS}" ]; then
-    echo "${OPERATION}faild."
+    echo "${OPERATION} faild."
     exit 2
   fi
 }


### PR DESCRIPTION
The error message needs space between $Operation and "failed".

```
{"code":"PR404-DV-0003","message":{"lang":"en","value":"Cell not found."}}
status:404
UNIT ADMIN Cell createdfaild.
```