### PR TITLE
Update commons_daemon_version to 1.2.2

### DIFF
--- a/1-server_unit/Ansible_Settings_Instruction.md
+++ b/1-server_unit/Ansible_Settings_Instruction.md
@@ -117,7 +117,7 @@ Below are the files where modification is required.
 
   tomcat_version: 9.0.27
 
-  commons_daemon_version : 1.1.0
+  commons_daemon_version : 1.2.2
 
   activemq_version: 5.15.8
 ```

--- a/1-server_unit/group_vars/ap.yml
+++ b/1-server_unit/group_vars/ap.yml
@@ -18,5 +18,5 @@ cache_manager: memcached
 
 
 tomcat_version: 9.0.27
-commons_daemon_version : 1.1.0
+commons_daemon_version : 1.2.2
 activemq_version: 5.15.8

--- a/3-server_unit/Ansible_Settings_Instruction.md
+++ b/3-server_unit/Ansible_Settings_Instruction.md
@@ -183,7 +183,7 @@ Below are the files where modification is required.
 
   tomcat_version: 9.0.27
 
-  commons_daemon_version : 1.1.0
+  commons_daemon_version : 1.2.2
 
   activemq_version: 5.15.8
 ```

--- a/3-server_unit/group_vars/ap.yml
+++ b/3-server_unit/group_vars/ap.yml
@@ -18,5 +18,5 @@ cache_manager: memcached
 
 
 tomcat_version: 9.0.27
-commons_daemon_version : 1.1.0
+commons_daemon_version : 1.2.2
 activemq_version: 5.15.8


### PR DESCRIPTION
To execute the playbook successfully, this modification is needed since `Tomcat` version up to 9.0.27 requires `commons daemon` version up to 1.2.2. 